### PR TITLE
Add autoscroll

### DIFF
--- a/src/main/java/org/qme/gui/LauncherWindow.java
+++ b/src/main/java/org/qme/gui/LauncherWindow.java
@@ -3,6 +3,7 @@ package org.qme.gui;
 import org.qme.installer.Installer;
 
 import javax.swing.*;
+import javax.swing.text.DefaultCaret;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -68,6 +69,10 @@ public class LauncherWindow extends JPanel implements ActionListener {
         outputArea.setEditable(false);
         JScrollPane outputPane = new JScrollPane(outputArea);
 
+        // Auto scroll down on update
+        outputPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+        DefaultCaret caret = (DefaultCaret)outputArea.getCaret();
+        caret.setUpdatePolicy(DefaultCaret.ALWAYS_UPDATE);
 
         textAreas.add(outputPane, "Output");
         textAreas.add(patchnotesPane, "Changelog");


### PR DESCRIPTION
Autoscroll output area on update. Also in order to implement this without using action listeners I needed to remove horizontal scrolling which is a good thing anyway since a console output really should have horizontal scrolling if anything it should wrap to the next line.